### PR TITLE
Add unique campaign ID handling and corresponding tests.

### DIFF
--- a/DSA-Campaign-Uplift-Estimation/src/main/java/com/google/sps/servlets/DSACampaignsServlet.java
+++ b/DSA-Campaign-Uplift-Estimation/src/main/java/com/google/sps/servlets/DSACampaignsServlet.java
@@ -132,11 +132,12 @@ public class DSACampaignsServlet extends HttpServlet {
 
     /**
      * assignUniqueCampaignId takes in a keyword campaign and the proposed dsaCampaignId and
-     * checks with datastore to determine if it already exists. If campaign ID already exists, 
-     * then this function returns the highest existing DSA campaign ID plus one.
+     * checks with datastore to determine if dsaCampaignId already exists. If campaign ID already exists, 
+     * then this method returns the highest existing DSA campaign ID plus one.
      *
      * @param correspondingKeywordCampaignId keyword campaign id associated with the DSA campaign.
      * @param dsaCampaignId                  The proposed DSA campaign ID.
+     * @return                               String representing available dsa campaign id.
      */
     public static String assignUniqueCampaignId(String correspondingKeywordCampaignId, String dsaCampaignId) {
       DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/DSA-Campaign-Uplift-Estimation/src/main/java/com/google/sps/servlets/DSACampaignsServlet.java
+++ b/DSA-Campaign-Uplift-Estimation/src/main/java/com/google/sps/servlets/DSACampaignsServlet.java
@@ -130,6 +130,14 @@ public class DSACampaignsServlet extends HttpServlet {
         return DSACampaignEntity;
     }
 
+    /**
+     * assignUniqueCampaignId takes in a keyword campaign and the proposed dsaCampaignId and
+     * checks with datastore to determine if it already exists. If campaign ID already exists, 
+     * then this function returns the highest existing DSA campaign ID plus one.
+     *
+     * @param correspondingKeywordCampaignId keyword campaign id associated with the DSA campaign.
+     * @param dsaCampaignId                  The proposed DSA campaign ID.
+     */
     public static String assignUniqueCampaignId(String correspondingKeywordCampaignId, String dsaCampaignId) {
       DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
       Query query = new Query("DSACampaign").setFilter(new Query.FilterPredicate("DSACampaignId", Query.FilterOperator.EQUAL, dsaCampaignId));

--- a/DSA-Campaign-Uplift-Estimation/src/test/java/com/google/sps/DSACampaignsServletTest.java
+++ b/DSA-Campaign-Uplift-Estimation/src/test/java/com/google/sps/DSACampaignsServletTest.java
@@ -126,12 +126,13 @@ public final class DSACampaignsServletTest {
       DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
       assertEquals(0, ds.prepare(new Query("DSACampaign")).countEntities(withLimit(10)));
 
-      DSACampaign DSACampaignObject = new DSACampaign("3", "2", "1", "Test DSA Campaign", "complete", "1/1/1", "2/2/2", 23.51, 20.12, 
+      String expectedCampaignId = "3";
+      DSACampaign DSACampaignObject = new DSACampaign(expectedCampaignId, "2", "1", "Test DSA Campaign", "complete", "1/1/1", "2/2/2", 23.51, 20.12, 
             "California, Texas", "google.com", "test1.com, test2.com", "sample ad text", 12412, 535, 2145.50);
       ds.put(DSACampaignsServlet.createEntityFromDSACampaign(DSACampaignObject));
       assertEquals(1, ds.prepare(new Query("DSACampaign")).countEntities(withLimit(10)));
 
-      String testInt = DSACampaignsServlet.assignUniqueCampaignId("1", "3");
+      String testCampaignId = DSACampaignsServlet.assignUniqueCampaignId("1", "3");
       DSACampaign DSACampaignObject2 = new DSACampaign(testInt, "2", "1", "Test DSA Campaign", "complete", "1/1/1", "2/2/2", 23.51, 20.12, 
             "California, Texas", "google.com", "test1.com, test2.com", "sample ad text", 12412, 535, 2145.50);
       ds.put(DSACampaignsServlet.createEntityFromDSACampaign(DSACampaignObject2));
@@ -139,12 +140,12 @@ public final class DSACampaignsServletTest {
       Query query = new Query("DSACampaign");
     	List<Entity> entities = ds.prepare(query).asList(FetchOptions.Builder.withLimit(2));
       
-      String stringValue = "3";
+      
       int intValue = 3;
       for (Entity entity : entities) {
-        assertEquals(stringValue, DSACampaignsServlet.createDSACampaignFromEntity(entity).DSACampaignId);
+        assertEquals(expectedCampaignId, DSACampaignsServlet.createDSACampaignFromEntity(entity).DSACampaignId);
         intValue++;
-        stringValue = Integer.toString(intValue);
+        expectedCampaignId = Integer.toString(intValue);
       }
     }
 }

--- a/DSA-Campaign-Uplift-Estimation/src/test/java/com/google/sps/DSACampaignsServletTest.java
+++ b/DSA-Campaign-Uplift-Estimation/src/test/java/com/google/sps/DSACampaignsServletTest.java
@@ -133,7 +133,7 @@ public final class DSACampaignsServletTest {
       assertEquals(1, ds.prepare(new Query("DSACampaign")).countEntities(withLimit(10)));
 
       String testCampaignId = DSACampaignsServlet.assignUniqueCampaignId("1", "3");
-      DSACampaign DSACampaignObject2 = new DSACampaign(testInt, "2", "1", "Test DSA Campaign", "complete", "1/1/1", "2/2/2", 23.51, 20.12, 
+      DSACampaign DSACampaignObject2 = new DSACampaign(testCampaignId, "2", "1", "Test DSA Campaign", "complete", "1/1/1", "2/2/2", 23.51, 20.12, 
             "California, Texas", "google.com", "test1.com, test2.com", "sample ad text", 12412, 535, 2145.50);
       ds.put(DSACampaignsServlet.createEntityFromDSACampaign(DSACampaignObject2));
       assertEquals(2, ds.prepare(new Query("DSACampaign")).countEntities(withLimit(10)));


### PR DESCRIPTION
Due to a servlet crash caused by duplicate campaign ID's, I added a method to create unique campaign ID's in '/DSA-campaigns' and tests to verify that the specific functionality works.